### PR TITLE
Fix syntax error in Ship of Harkinian.sh

### DIFF
--- a/Ship of Harkinian.sh
+++ b/Ship of Harkinian.sh
@@ -26,7 +26,7 @@ source $controlfolder/device_info.txt
 # Set current virtual screen
 if [ "$CFW_NAME" == "muOS" ]; then
   /opt/muos/extra/muxlog & CUR_TTY="/tmp/muxlog_info"
-else if [ "$CFW_NAME" == "TrimUI" ]; then
+elif [ "$CFW_NAME" == "TrimUI" ]; then
   CUR_TTY="/dev/fd/1"
 else
   CUR_TTY="/dev/tty0"


### PR DESCRIPTION
With a fresh install through PortMaster GUI client in muOS, it would fail with the error:

```
# RG35XX H - muOS
bash
DEVICE_INFO_VERSION=0.1.9
PM_VERSION=2024.07.17-1125
CFW_NAME=muOS
CFW_VERSION=2405.2 BAKED BEANS
DEVICE_NAME=RG35XX H
DEVICE_CPU=H700
DEVICE_ARCH=aarch64
DEVICE_RAM=1
DEVICE_HAS_ARMHF="Y"
DEVICE_HAS_AARCH64="Y"
DEVICE_HAS_X86="N"
DEVICE_HAS_X86_64="N"
DISPLAY_WIDTH=640
DISPLAY_HEIGHT=480
ASPECT_X=4
ASPECT_Y=3
DISPLAY_ORIENTATION=0
ANALOG_STICKS=2

/mnt/mmc/ROMS/Ports/Ship of Harkinian.sh: line 101: syntax error: unexpected end of file
```
After this fix everything is working with latest commit.